### PR TITLE
Removed routes in server config. 

### DIFF
--- a/roles/openvpn/templates/server.conf.j2
+++ b/roles/openvpn/templates/server.conf.j2
@@ -7,16 +7,5 @@ ping-timer-rem
 persist-tun
 persist-key
 cipher AES-256-CBC
-# Add each libvirt network we set up so the client configures the routes to go through the tun interface
-
-{% if libvirt_networks is defined %}
-{% for network in libvirt_networks %}
-route {{ network.address }} {{ network.netmask }} {{ openvpn_network_gw }}
-{% endfor %}
-{% else %}
-# No networks defined in libvirt_networks:
-# so no routes added
-{% endif %}
-
 secret static.key
 


### PR DESCRIPTION
labhost acts as gateway so no additonal rules are needed.

It messes up libvirt_network, where tun0 has taken up the network.
```
TASK [libvirt_network : Defining network mgmt] ********************************************************************************************************************************************************************
Monday 14 January 2019  12:25:02 +0100 (0:00:00.121)       0:00:20.867 ******** 
changed: [88.99.5.77]

TASK [libvirt_network : Enable and Autostart virtual network mgmt] ************************************************************************************************************************************************
Monday 14 January 2019  12:25:03 +0100 (0:00:00.711)       0:00:21.579 ******** 
fatal: [88.99.5.77]: FAILED! => {"changed": false, "msg": "internal error: Network is already in use by interface tun0"}
```
