### PR TITLE
Iptables

### DIFF
--- a/adhoc/ansible.cfg
+++ b/adhoc/ansible.cfg
@@ -1,0 +1,13 @@
+[defaults]
+host_key_checking = False
+nocows = 1
+callback_whitelist = profile_tasks
+retry_files_enabled = False
+roles_path = ../roles/:./roles/
+
+[ssh_connection]
+ssh_args = -o ControlMaster=auto -o ControlPersist=600s
+control_path = %(directory)s/%%h-%%r
+pipelining = True 
+timeout = 10
+

--- a/adhoc/port-opening.yml
+++ b/adhoc/port-opening.yml
@@ -1,0 +1,13 @@
+---
+# 
+- hosts: labhost
+  tasks:
+  - name: Open port 8443/tcp from net1 to net2
+    import_role:
+      name: iptables
+      tasks_from: port-opening.yml
+    vars:
+      from_net: net1
+      to_net: net2
+      port: 8443
+      proto: tcp

--- a/adhoc/tear_down_networks.yml
+++ b/adhoc/tear_down_networks.yml
@@ -1,0 +1,28 @@
+- hosts: labhost
+  become: true
+  tasks:
+  - name: destroy libvirt_networks
+    virt_net: 
+      command: destroy 
+      name: "{{ network.name }}"
+    loop: "{{ libvirt_networks }}"
+    loop_control:
+      loop_var: network
+    failed_when: false
+
+  - name: undefine libvirt_networks
+    virt_net: 
+      command: undefine
+      name: "{{ network.name }}"
+    loop: "{{ libvirt_networks }}"
+    loop_control:
+      loop_var: network
+
+  - name: cleanup iptable rules
+    include_role:
+      name: iptables
+      tasks_from: delete-libvirt-network.yml
+    loop: "{{ libvirt_networks }}"
+    loop_control:
+      loop_var: network
+

--- a/roles/iptables/README.md
+++ b/roles/iptables/README.md
@@ -20,14 +20,14 @@ So if you have three networks:
 - net2
 
 The following FORWARD chains will be created:
-net1-to-mgmt: Traffic flowing from net1 to mgmt
-net2-to-mgmt: Traffic flowing from net2 to mgmt
+net1-to-mgmt: Traffic flowing from net1 to mgmt  
+net2-to-mgmt: Traffic flowing from net2 to mgmt  
 
-mgmt-to-net1: Traffic flowing from mgmt to net1
-net2-to-net1: Traffic flowing from net2 to net1
+mgmt-to-net1: Traffic flowing from mgmt to net1  
+net2-to-net1: Traffic flowing from net2 to net1  
 
-mgmt-to-net2: Traffic flowing from mgmt to net2
-net1-to-net2: Traffic flowing from net1 to net2
+mgmt-to-net2: Traffic flowing from mgmt to net2  
+net1-to-net2: Traffic flowing from net1 to net2  
 
 
 These chains comes empty, so by default nothing is Opened.

--- a/roles/iptables/README.md
+++ b/roles/iptables/README.md
@@ -1,0 +1,38 @@
+Labhost iptables
+================
+
+Creates the basic structure of keeping networks restricted.
+
+The idea here is that we use "Open" networks with libvirt, and then create the forwarding ourselves.
+Each network will have Chains for the incoming traffic from each network.
+
+
+The math becomes 
+```
+n = no. of libvirt_networks
+amount of chains = n * ( n - 1)
+
+```
+
+So if you have three networks:
+- mgmt
+- net1
+- net2
+
+The following FORWARD chains will be created:
+net1-to-mgmt: Traffic flowing from net1 to mgmt
+net2-to-mgmt: Traffic flowing from net2 to mgmt
+
+mgmt-to-net1: Traffic flowing from mgmt to net1
+net2-to-net1: Traffic flowing from net2 to net1
+
+mgmt-to-net2: Traffic flowing from mgmt to net2
+net1-to-net2: Traffic flowing from net1 to net2
+
+
+These chains comes empty, so by default nothing is Opened.
+When we do want to allow a specific port from one network to the other, we can simply append it to the proper chain.
+Say we want open for a webserver on mgmt to hosts on net1, we can do the following:
+```
+iptables -A net1-to-mgmt -d 10.15.0.50 -p tcp -m tcp --dport 80 -j ACCEPT -m comment --comment "Allow port 80"
+```

--- a/roles/iptables/README.md
+++ b/roles/iptables/README.md
@@ -19,7 +19,8 @@ So if you have three networks:
 - net1
 - net2
 
-The following FORWARD chains will be created:
+The following FORWARD chains will be created:  
+```
 net1-to-mgmt: Traffic flowing from net1 to mgmt  
 net2-to-mgmt: Traffic flowing from net2 to mgmt  
 
@@ -28,7 +29,7 @@ net2-to-net1: Traffic flowing from net2 to net1
 
 mgmt-to-net2: Traffic flowing from mgmt to net2  
 net1-to-net2: Traffic flowing from net1 to net2  
-
+```
 
 These chains comes empty, so by default nothing is Opened.
 When we do want to allow a specific port from one network to the other, we can simply append it to the proper chain.

--- a/roles/iptables/tasks/delete-libvirt-network.yml
+++ b/roles/iptables/tasks/delete-libvirt-network.yml
@@ -1,0 +1,34 @@
+---
+
+- name: create a list of all networks except {{ network.name }}
+  set_fact:
+    other_nets: []
+
+- name: add networks to list except {{ network.name }}
+  set_fact:
+    other_nets: "{{ other_nets }} + [ '{{ item.name }}' ]"
+  with_items: "{{ libvirt_networks }}"
+  when: "'{{ network.name }}' not in item.name"
+
+- name: print list
+  debug:
+    msg: "{{ other_nets }}"
+
+- name: Flush chains to {{ network.name }}
+  command: "iptables -F {{ item }}-to-{{ network.name }}"
+  with_items: "{{ other_nets }}"
+  failed_when: false
+
+- name: Delete FORWARD rule to chain {{ network.name }}
+  command: "iptables -D FORWARD -i virbr-{{ item }} -o virbr-{{ network.name }} -m comment --comment 'jump to {{ item }}-to-{{ network.name }}' -j {{ item }}-to-{{ network.name }}"
+  with_items: "{{ other_nets }}"
+  failed_when: false
+
+- name: Delete chains to {{ network.name }}
+  command: "iptables -X {{ item }}-to-{{ network.name }}"
+  with_items: "{{ other_nets }}"
+  ignore_errors: true
+
+- name: Delete Allow all INPUT to network {{ network.name }}
+  command: "iptables -D INPUT -i virbr-{{ network.name }} -m comment --comment 'Allow all incoming packages on virbr-{{ network.name }}. Filtering happens in FORWARD' -j ACCEPT"
+

--- a/roles/iptables/tasks/libvirt-network.yml
+++ b/roles/iptables/tasks/libvirt-network.yml
@@ -46,6 +46,13 @@
     out_interface: virbr-{{ network.name }}
   with_items: "{{ other_nets }}"
 
+- name: "Add DROP log rule to each -to-{{ network.name }} chain"
+  iptables:
+    chain: "{{ item }}-to-{{ network.name }}"
+    jump: LOG
+    log_prefix: "DROP ({{ item }}-to-{{ network.name }}): "
+  with_items: "{{ other_nets }}"
+
 - name: Allow all INPUT to network {{ network.name }}
   iptables:
     action: insert

--- a/roles/iptables/tasks/libvirt-network.yml
+++ b/roles/iptables/tasks/libvirt-network.yml
@@ -1,6 +1,8 @@
 ---
+# This will create the FORWARD chains needed to set port openings per network combination.
 # 
-#
+# The task list expects a network object of the "open-network" type. See roles/libvirt_networks/README.md
+# It expects the bridge interface to have the name virbr-<network-name> 
 #
 
 - name: create a list of all networks except {{ network.name }}

--- a/roles/iptables/tasks/libvirt-network.yml
+++ b/roles/iptables/tasks/libvirt-network.yml
@@ -1,0 +1,55 @@
+---
+# 
+#
+#
+
+- name: create a list of all networks except {{ network.name }}
+  set_fact:
+    other_nets: []
+
+- name: add networks to list except {{ network.name }}
+  set_fact:
+    other_nets: "{{ other_nets }} + [ '{{ item.name }}' ]"
+  with_items: "{{ libvirt_networks }}"
+  when: "'{{ network.name }}' not in item.name"
+
+- name: print list
+  debug:
+    msg: "{{ other_nets }}"
+
+- name: create the chains to {{ network.name }}
+  command: "iptables -N {{ item }}-to-{{ network.name }}"
+  with_items: "{{ other_nets }}"
+  ignore_errors: true
+
+- name: Allow inter-lan traffic on the network
+  iptables:
+    chain: FORWARD
+    action: insert
+    rule_num: 2
+    in_interface: "virbr-{{ network.name }}"
+    out_interface: "virbr-{{ network.name }}"
+    jump: ACCEPT
+    comment: "Allow inter-LAN traffic for {{ network.name }}"
+
+
+- name: Create FORWARD rule to chain {{ network.name }}
+  iptables:
+    action: insert
+    rule_num: 3
+    chain: FORWARD
+    jump: "{{ item }}-to-{{ network.name }}"
+    comment: "jump to {{ item }}-to-{{ network.name }}"
+    in_interface: virbr-{{ item }}
+    out_interface: virbr-{{ network.name }}
+  with_items: "{{ other_nets }}"
+
+- name: Allow all INPUT to network {{ network.name }}
+  iptables:
+    action: insert
+    rule_num: 2
+    chain: INPUT
+    jump: ACCEPT
+    in_interface: virbr-{{ network.name }}
+    comment: "Allow all incoming packages on virbr-{{ network.name }}. Filtering happens in FORWARD"
+

--- a/roles/iptables/tasks/main.yml
+++ b/roles/iptables/tasks/main.yml
@@ -17,9 +17,13 @@
     chain: FORWARD
     policy: DROP
 
-# Now we loop through all of our networks
+# Now we loop through all of our libvirt_networks
+# If it's a open_network, we will configure FORWARDing and lock it down ourselves
 - name: Configure rules for all libvirt_networks
   include_tasks: libvirt-network.yml
   loop: "{{ libvirt_networks }}"
   loop_control:
     loop_var: network
+  when: "'open_network' in network.type"
+
+# SAVE RULES

--- a/roles/iptables/tasks/main.yml
+++ b/roles/iptables/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+#
+#
+#
+
+- name: Allow all related and established connection on FORWARD
+  iptables:
+    action: insert
+    rule_num: 1
+    chain: FORWARD
+    ctstate: ESTABLISHED,RELATED
+    jump: ACCEPT
+  become: yes
+
+- name: Set default policy on FORWARD to DROP
+  iptables:
+    chain: FORWARD
+    policy: DROP
+
+# Now we loop through all of our networks
+- name: Configure rules for all libvirt_networks
+  include_tasks: libvirt-network.yml
+  loop: "{{ libvirt_networks }}"
+  loop_control:
+    loop_var: network

--- a/roles/iptables/tasks/port-opening.yml
+++ b/roles/iptables/tasks/port-opening.yml
@@ -1,0 +1,20 @@
+---
+# This tasklist is meant to be called upon outside of the main.yml
+# Basically, you would do the role inclusion and spcify the tasklist
+#
+# import_role:
+#   name: iptables
+#   tasks_from: port-opening.yml
+# vars:
+#   from_net: 
+#   to_net:
+#   port: 
+#   proto: 
+
+
+- name: "add ACCEPT rule to chain {{ from_net }}-to-{{ to_net }}"
+  iptables:
+    chain: "{{from_net}}-to-{{to_net}}"
+    jump: ACCEPT
+    destination_port: {{ port }}
+    protocol: "{{ proto }}" 

--- a/roles/iptables/tasks/port-opening.yml
+++ b/roles/iptables/tasks/port-opening.yml
@@ -13,8 +13,9 @@
 
 
 - name: "add ACCEPT rule to chain {{ from_net }}-to-{{ to_net }}"
+  become: true
   iptables:
     chain: "{{from_net}}-to-{{to_net}}"
     jump: ACCEPT
-    destination_port: {{ port }}
+    destination_port: "{{ port }}"
     protocol: "{{ proto }}" 

--- a/roles/libvirt_network/templates/open_network.xml.j2
+++ b/roles/libvirt_network/templates/open_network.xml.j2
@@ -1,0 +1,11 @@
+<network>
+  <name>{{ network.name }}</name>
+  <forward mode='open'/>
+  <bridge name='virbr-{{ network.name }}' stp='on' delay='0'/>
+  <domain name='open'/>
+  <ip address="{{ network.interface_address }}" netmask="{{ netmask | default('255.255.255.0') }}">
+    <dhcp>
+      <range start='{{ network.dhcp_range_start }}' end='{{ network.dhcp_range_stop }}'/>
+    </dhcp>
+  </ip>
+</network>


### PR DESCRIPTION
role to create network rules for all libvirt_networks: 
the networks are locked down by default, and creates chains between all of them so you can add accept rules in every direction.
Will log every dropped package for easier troubleshooting