### PR TITLE
Centos repo fix

### DIFF
--- a/roles/reposync/tasks/centos-repo.yml
+++ b/roles/reposync/tasks/centos-repo.yml
@@ -1,0 +1,22 @@
+
+- name: get certs
+  shell: "ls /etc/pki/entitlement/*  | grep -v '\\-key.pem'"
+  register: certs
+
+- name: set_fact certs
+  set_fact:
+    cdn_certs: "{{ certs.stdout_lines }}"
+
+- name: get keys
+  #command: "ls /etc/pki/entitlement/*-key.pem"
+  shell: "ls /etc/pki/entitlement/*  | grep  '\\-key.pem'"
+  register: cdn_keys
+
+- name: set_fact
+  set_fact:
+    cdn_keys: "{{ cdn_keys.stdout_lines }}"
+
+- name: (CentOS) configure rhel-7-server-rpms repo
+  template:
+    src: rhel.repo.j2
+    dest: /etc/yum.repos.d/rhel-7-server-rpms.repo

--- a/roles/reposync/tasks/setup.yml
+++ b/roles/reposync/tasks/setup.yml
@@ -43,9 +43,16 @@
 
 - name: enable 7Server
   command: subscription-manager release --set 7Server
+  when: ansible_distribution != 'CentOS'
 
 - name: enable rhel-7-server-rpms
   command: subscription-manager
+  when: ansible_distribution != 'CentOS'
+
+
+- name: CentOS workaround
+  include_tasks: centos-repo.yml
+  when: ansible_distribution == 'CentOS'
 
 # Fire and forget. Allow up to 2hours
 - name: start reposync
@@ -54,11 +61,10 @@
   poll: 0
   register: reposync_job
 
-- name: unset release
-  command: subscription-manager release --unset
-  when: ansible_distribution == 'CentOS'
-
-- name: disable rhel-7-server
-  command: subscription-manager repos --disable rhel-7-server-rpms
+- name: (CentOS) disable rhel-7-server-rpms repo
+  lineinfile:
+    path: /etc/yum.repos.d/rhel-7-server-rpms.repo
+    regexp: '^enabled'
+    line: 'enabled = 0'
   when: ansible_distribution == 'CentOS'
 

--- a/roles/reposync/templates/rhel.repo.j2
+++ b/roles/reposync/templates/rhel.repo.j2
@@ -1,8 +1,9 @@
 [rhel-7-server-rpms]
-sslclientcert = {{ cert }}
-sslclientkey = {{ key }}
+name = rhel-7-server-rpms
+sslclientcert = {{ cdn_certs[0] }}
+sslclientkey = {{ cdn_keys[0] }}
 baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/x86_64/os/
-enabled = 0
+enabled = 1
 gpgcheck = 0
-ssl_verify = 0
+sslverify = 0
 sslcacert = /etc/rhsm/ca/redhat-uep.pem


### PR DESCRIPTION
```
TASK [subman : attach] ********************************************************************************************************************************************************************************************
Thursday 31 January 2019  10:40:13 +0100 (0:00:00.080)       0:00:21.233 ****** 
skipping: [labhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [reposync : check for phase] *********************************************************************************************************************************************************************************
Thursday 31 January 2019  10:40:13 +0100 (0:00:00.105)       0:00:21.339 ****** 
ok: [labhost] => {
    "changed": false, 
    "msg": "All assertions passed"
}

TASK [reposync : 1st phase: Setup] ********************************************************************************************************************************************************************************
Thursday 31 January 2019  10:40:14 +0100 (0:00:00.136)       0:00:21.476 ****** 
included: /home/moss/infohub/consulting-lab/roles/reposync/tasks/setup.yml for labhost

TASK [reposync : install packages] ********************************************************************************************************************************************************************************
Thursday 31 January 2019  10:40:14 +0100 (0:00:00.149)       0:00:21.625 ****** 
ok: [labhost] => {"changed": false, "msg": "", "rc": 0, "results": ["httpd-2.4.6-88.el7.centos.x86_64 providing httpd is already installed", "python-mako-0.8.1-2.el7.noarch providing python-mako is already installed", "yum-utils-1.1.31-50.el7.noarch providing yum-utils is already installed", "createrepo-0.9.9-28.el7.noarch providing createrepo is already installed", "policycoreutils-python-2.5-29.el7.x86_64 providing policycoreutils-python is already installed"]}

TASK [reposync : create pub directory for repos] ******************************************************************************************************************************************************************
Thursday 31 January 2019  10:40:21 +0100 (0:00:07.380)       0:00:29.005 ****** 
ok: [labhost] => {"changed": false, "gid": 48, "group": "apache", "mode": "0755", "owner": "apache", "path": "/var/www/html/pub/repos", "secontext": "unconfined_u:object_r:httpd_sys_content_t:s0", "size": 22, "state": "directory", "uid": 48}

TASK [reposync : remove welcome.conf] *****************************************************************************************************************************************************************************
Thursday 31 January 2019  10:40:22 +0100 (0:00:00.511)       0:00:29.517 ****** 
ok: [labhost] => {"changed": false, "path": "/etc/httpd/conf.d/welcome.conf", "state": "absent"}

TASK [reposync : remove userdir.conf] *****************************************************************************************************************************************************************************
Thursday 31 January 2019  10:40:22 +0100 (0:00:00.366)       0:00:29.883 ****** 
ok: [labhost] => {"changed": false, "path": "/etc/httpd/conf.d/userdir.conf", "state": "absent"}

TASK [reposync : create repos vhost] ******************************************************************************************************************************************************************************
Thursday 31 January 2019  10:40:22 +0100 (0:00:00.396)       0:00:30.280 ****** 
ok: [labhost] => {"changed": false, "checksum": "12e257985b47e04a8f2e36b7d7243335bd6603de", "dest": "/etc/httpd/conf.d/repos.conf", "gid": 0, "group": "root", "mode": "01204", "owner": "root", "path": "/etc/httpd/conf.d/repos.conf", "secontext": "system_u:object_r:httpd_config_t:s0", "size": 75, "state": "file", "uid": 0}

TASK [reposync : enable httpd] ************************************************************************************************************************************************************************************
Thursday 31 January 2019  10:40:23 +0100 (0:00:01.023)       0:00:31.304 ****** 
changed: [labhost] => {"changed": true, "enabled": true, "name": "httpd", "state": "started", "status": {"ActiveEnterTimestamp": "Thu 2019-01-31 09:57:55 CET", "ActiveEnterTimestampMonotonic

-- trimmed --
"WatchdogTimestamp": "Thu 2019-01-31 09:57:55 CET", "WatchdogTimestampMonotonic": "67906566638", "WatchdogUSec": "0"}}

TASK [reposync : enable 7Server] **********************************************************************************************************************************************************************************
Thursday 31 January 2019  10:40:25 +0100 (0:00:01.574)       0:00:32.878 ****** 
skipping: [labhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [reposync : enable rhel-7-server-rpms] ***********************************************************************************************************************************************************************
Thursday 31 January 2019  10:40:25 +0100 (0:00:00.076)       0:00:32.955 ****** 
skipping: [labhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [reposync : CentOS workaround] *******************************************************************************************************************************************************************************
Thursday 31 January 2019  10:40:25 +0100 (0:00:00.076)       0:00:33.032 ****** 
included: /home/moss/infohub/consulting-lab/roles/reposync/tasks/centos-repo.yml for labhost

TASK [reposync : get certs] ***************************************************************************************************************************************************************************************
Thursday 31 January 2019  10:40:25 +0100 (0:00:00.144)       0:00:33.176 ****** 
changed: [labhost] => {"changed": true, "cmd": "ls /etc/pki/entitlement/* | grep -v '\\-key.pem'", "delta": "0:00:00.008060", "end": "2019-01-31 10:40:26.072629", "rc": 0, "start": "2019-01-31 10:40:26.064569", "stderr": "", "stderr_lines": [], "stdout": "/etc/pki/entitlement/4246252518979755445.pem", "stdout_lines": ["/etc/pki/entitlement/4246252518979755445.pem"]}

TASK [reposync : set_fact certs] **********************************************************************************************************************************************************************************
Thursday 31 January 2019  10:40:26 +0100 (0:00:00.498)       0:00:33.674 ****** 
ok: [labhost] => {"ansible_facts": {"cdn_certs": ["/etc/pki/entitlement/4246252518979755445.pem"]}, "changed": false}

TASK [reposync : get keys] ****************************************************************************************************************************************************************************************
Thursday 31 January 2019  10:40:26 +0100 (0:00:00.108)       0:00:33.782 ****** 
changed: [labhost] => {"changed": true, "cmd": "ls /etc/pki/entitlement/* | grep '\\-key.pem'", "delta": "0:00:00.008143", "end": "2019-01-31 10:40:26.662829", "rc": 0, "start": "2019-01-31 10:40:26.654686", "stderr": "", "stderr_lines": [], "stdout": "/etc/pki/entitlement/4246252518979755445-key.pem", "stdout_lines": ["/etc/pki/entitlement/4246252518979755445-key.pem"]}

TASK [reposync : set_fact] ****************************************************************************************************************************************************************************************
Thursday 31 January 2019  10:40:26 +0100 (0:00:00.459)       0:00:34.242 ****** 
ok: [labhost] => {"ansible_facts": {"cdn_keys": ["/etc/pki/entitlement/4246252518979755445-key.pem"]}, "changed": false}

TASK [reposync : (CentOS) configure rhel-7-server-rpms repo] ******************************************************************************************************************************************************
Thursday 31 January 2019  10:40:26 +0100 (0:00:00.183)       0:00:34.426 ****** 
changed: [labhost] => {"changed": true, "checksum": "3af89cab3931ebb548675aa2950031c5446fcf57", "dest": "/etc/yum.repos.d/rhel-7-server-rpms.repo", "gid": 0, "group": "root", "md5sum": "61ce592b31145928304efc6fb6a71a6c", "mode": "0644", "owner": "root", "secontext": "system_u:object_r:system_conf_t:s0", "size": 330, "src": "/root/.ansible/tmp/ansible-tmp-1548927627.07-143968795966301/source", "state": "file", "uid": 0}

TASK [reposync : start reposync] **********************************************************************************************************************************************************************************
Thursday 31 January 2019  10:40:28 +0100 (0:00:01.939)       0:00:36.366 ****** 
changed: [labhost] => {"ansible_job_id": "594669557615.19250", "changed": true, "finished": 0, "results_file": "/root/.ansible_async/594669557615.19250", "started": 1}

TASK [reposync : (CentOS) disable rhel-7-server-rpms repo] ********************************************************************************************************************************************************
Thursday 31 January 2019  10:40:31 +0100 (0:00:02.461)       0:00:38.827 ****** 
changed: [labhost] => {"backup": "", "changed": true, "msg": "line replaced"}

TASK [reposync : 2nd phase: Final] ********************************************************************************************************************************************************************************
Thursday 31 January 2019  10:40:31 +0100 (0:00:00.470)       0:00:39.297 ****** 
skipping: [labhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [libvirt : install packages] *********************************************************************************************************************************************************************************
--- trimmed ---

TASK [reposync : check for phase] *********************************************************************************************************************************************************************************
Thursday 31 January 2019  10:41:11 +0100 (0:00:00.396)       0:01:18.908 ****** 
ok: [labhost] => {
    "changed": false, 
    "msg": "All assertions passed"
}

TASK [reposync : 1st phase: Setup] ********************************************************************************************************************************************************************************
Thursday 31 January 2019  10:41:11 +0100 (0:00:00.156)       0:01:19.065 ****** 
skipping: [labhost] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [reposync : 2nd phase: Final] ********************************************************************************************************************************************************************************
Thursday 31 January 2019  10:41:11 +0100 (0:00:00.079)       0:01:19.145 ****** 
included: /home/moss/infohub/consulting-lab/roles/reposync/tasks/final.yml for labhost

TASK [reposync : Wait for the reposync job to finish] *************************************************************************************************************************************************************
Thursday 31 January 2019  10:41:11 +0100 (0:00:00.138)       0:01:19.283 ****** 
FAILED - RETRYING: Wait for the reposync job to finish (300 retries left).
FAILED - RETRYING: Wait for the reposync job to finish (299 retries left).
FAILED - RETRYING: Wait for the reposync job to finish (298 retries left).
FAILED - RETRYING: Wait for the reposync job to finish (297 retries left).
FAILED - RETRYING: Wait for the reposync job to finish (296 retries left).
FAILED - RETRYING: Wait for the reposync job to finish (295 retries left).
FAILED - RETRYING: Wait for the reposync job to finish (294 retries left).
FAILED - RETRYING: Wait for the reposync job to finish (293 retries left).
FAILED - RETRYING: Wait for the reposync job to finish (292 retries left).
FAILED - RETRYING: Wait for the reposync job to finish (291 retries left).
FAILED - RETRYING: Wait for the reposync job to finish (290 retries left).
FAILED - RETRYING: Wait for the reposync job to finish (289 retries left).
FAILED - RETRYING: Wait for the reposync job to finish (288 retries left).
FAILED - RETRYING: Wait for the reposync job to finish (287 retries left).
FAILED - RETRYING: Wait for the reposync job to finish (286 retries left).
FAILED - RETRYING: Wait for the reposync job to finish (285 retries left).


376): zip-3.0-11.el 99% [===============-] 3.9 MB/s | 4.4 GB   00:01 ETA ", "", "(5368/5376): zenity-3.28.1-1.el7.x86_64.rpm                | 4.0 MB   00:00     ", "", "(5369/5376): zip-3.0-11.el7.x86_64.rpm                     | 260 kB   00:00     ", "", "(5370/5376): zlib-1.2.7-18.el7.i686.rpm                    |  91 kB   00:00     ", "", "(5372/5376): zlib-devel-1. 99% [===============-] 4.4 MB/s | 4.4 GB   00:00 ETA ", "", "(5371/5376): zlib-1.2.7-18.el7.x86_64.rpm                  |  90 kB   00:00     ", "", "(5372/5376): zlib-devel-1.2.7-18.el7.i686.rpm              |  50 kB   00:00     ", "", "(5373/5376): zsh-5.0.2-31.el7.x86_64.rpm                   | 2.4 MB   00:00     ", "", "(5374/5376): zlib-devel-1. 99% [===============-] 4.2 MB/s | 4.4 GB   00:00 ETA ", "", "(5374/5376): zlib-devel-1.2.7-18.el7.x86_64.rpm            |  50 kB   00:00     ", "", "(5375/5376): zziplib-0.13.62-9.el7.i686.rpm                |  82 kB   00:00     ", "", "(5376/5376): zziplib-0.13. 99% [===============-] 3.9 MB/s | 4.4 GB   00:00 ETA ", "", "(5376/5376): zziplib-0.13.62-9.el7.x86_64.rpm              |  82 kB   00:00     "]}

TASK [reposync : Run createrepo in /var/www/html/pub/repos/] ******************************************************************************************************************************************************
Thursday 31 January 2019  10:57:27 +0100 (0:16:16.002)       0:17:35.285 ****** 
changed: [labhost] => {"changed": true, "cmd": ["createrepo", "/var/www/html/pub/repos/"], "delta": "0:00:15.821004", "end": "2019-01-31 10:57:43.960336", "rc": 0, "start": "2019-01-31 10:57:28.139332", "stderr": "", "stderr_lines": [], "stdout": "Spawning worker 0 with 448 pkgs\nSpawning worker 1 with 448 pkgs\nSpawning worker 2 with 448 pkgs\nSpawning worker 3 with 448 pkgs\nSpawning worker 4 with 448 pkgs\nSpawning worker 5 with 448 pkgs\nSpawning worker 6 with 448 pkgs\nSpawning worker 7 with 448 pkgs\nSpawning worker 8 with 448 pkgs\nSpawning worker 9 with 448 pkgs\nSpawning worker 10 with 448 pkgs\nSpawning worker 11 with 448 pkgs\nWorkers Finished\nSaving Primary metadata\nSaving file lists metadata\nSaving other metadata\nGenerating sqlite DBs\nSqlite DBs complete", "stdout_lines": ["Spawning worker 0 with 448 pkgs", "Spawning worker 1 with 448 pkgs", "Spawning worker 2 with 448 pkgs", "Spawning worker 3 with 448 pkgs", "Spawning worker 4 with 448 pkgs", "Spawning worker 5 with 448 pkgs", "Spawning worker 6 with 448 pkgs", "Spawning worker 7 with 448 pkgs", "Spawning worker 8 with 448 pkgs", "Spawning worker 9 with 448 pkgs", "Spawning worker 10 with 448 pkgs", "Spawning worker 11 with 448 pkgs", "Workers Finished", "Saving Primary metadata", "Saving file lists metadata", "Saving other metadata", "Generating sqlite DBs", "Sqlite DBs complete"]}

TASK [reposync : sefcontext] **************************************************************************************************************************************************************************************
Thursday 31 January 2019  10:57:44 +0100 (0:00:16.270)       0:17:51.556 ****** 
ok: [labhost] => {"changed": false, "ftype": "a", "serange": "s0", "setype": "httpd_sys_content_t", "seuser": "system_u", "state": "present", "target": "/var/www/html/pub(/.*)?"}

TASK [reposync : restorecon] **************************************************************************************************************************************************************************************
Thursday 31 January 2019  10:57:44 +0100 (0:00:00.745)       0:17:52.301 ****** 
changed: [labhost] => {"changed": true, "cmd": ["restorecon", "-Rvi", "/var/www/html/pub/repos/"], "delta": "0:00:00.311627", "end": "2019-01-31 10:57:45.447368", "rc": 0, "start": "2019-01-31 10:57:45.135741", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [mdadm-sync : start the mdadm sync (max)] ********************************************************************************************************************************************************************
Thursday 31 January 2019  10:57:45 +0100 (0:00:00.759)       0:17:53.061 ****** 
changed: [labhost] => {"changed": true, "cmd": "echo 300000 > /proc/sys/dev/raid/speed_limit_max", "delta": "0:00:00.005852", "end": "2019-01-31 10:57:45.900978", "rc": 0, "start": "2019-01-31 10:57:45.895126", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [mdadm-sync : start the mdadm sync (min)] ********************************************************************************************************************************************************************
Thursday 31 January 2019  10:57:46 +0100 (0:00:00.425)       0:17:53.486 ****** 
changed: [labhost] => {"changed": true, "cmd": "echo 50000 > /proc/sys/dev/raid/speed_limit_min", "delta": "0:00:00.005490", "end": "2019-01-31 10:57:46.278626", "rc": 0, "start": "2019-01-31 10:57:46.273136", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [mdadm-sync : temporarily pause the mdadm sync (max)] ********************************************************************************************************************************************************
Thursday 31 January 2019  10:57:46 +0100 (0:00:00.381)       0:17:53.867 ****** 
changed: [labhost] => {"changed": true, "cmd": "echo 0 > /proc/sys/dev/raid/speed_limit_max", "delta": "0:00:00.005497", "end": "2019-01-31 10:57:46.659829", "rc": 0, "start": "2019-01-31 10:57:46.654332", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [mdadm-sync : temporarily pause the mdadm sync (min)] ********************************************************************************************************************************************************
Thursday 31 January 2019  10:57:46 +0100 (0:00:00.378)       0:17:54.245 ****** 
changed: [labhost] => {"changed": true, "cmd": "echo 0 > /proc/sys/dev/raid/speed_limit_min", "delta": "0:00:00.005375", "end": "2019-01-31 10:57:47.027680", "rc": 0, "start": "2019-01-31 10:57:47.022305", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

PLAY RECAP ********************************************************************************************************************************************************************************************************
labhost                    : ok=103  changed=23   unreachable=0    failed=0   
```