### PR TITLE
turn off SSL validation if CentOS. We don't have the certs

### DIFF
--- a/roles/subman/tasks/main.yml
+++ b/roles/subman/tasks/main.yml
@@ -9,6 +9,13 @@
     name: subscription-manager
     state: installed
 
+- name: (CentOS) turn off SSL verify
+  lineinfile:
+    path: /etc/rhsm/rhsm.conf
+    line: 'insecure = 1'
+    regexp: '^insecure'
+  when: ansible_distribution == 'CentOS'
+
 - name: check subscription status
   command: subscription-manager status
   ignore_errors: true


### PR DESCRIPTION
Otherwise we will end up with:
```
# subscription-manager register 
Registering to: subscription.rhsm.redhat.com:443/subscription
Username: consultant@redhat.com
Password: 
Unable to verify server's identity: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:618)
```