### PR TITLE
use temporary cache

### DIFF
--- a/roles/reposync/tasks/setup.yml
+++ b/roles/reposync/tasks/setup.yml
@@ -56,7 +56,7 @@
 
 # Fire and forget. Allow up to 2hours
 - name: start reposync
-  shell: reposync -p "/var/www/html/pub/repos/" --repoid=rhel-7-server-rpms -m -n | tee /var/log/reposync.$(date +%Y%m%d).log
+  shell: reposync -p "/var/www/html/pub/repos/" --repoid=rhel-7-server-rpms -m -n -t | tee /var/log/reposync.$(date +%Y%m%d).log
   async: 7200
   poll: 0
   register: reposync_job


### PR DESCRIPTION
Fixes: https://github.com/redhatNORDICS/consulting-lab/issues/32

Wwen using a different cache we don't see the error. 
related: 
http://lists.baseurl.org/pipermail/yum-devel/2012-December/009813.html
https://bugzilla.redhat.com/show_bug.cgi?id=880722